### PR TITLE
Don't create Gemfile before building jhipster.github.io

### DIFF
--- a/playbooks/roles/documentation-archive-prepare/tasks/main.yml
+++ b/playbooks/roles/documentation-archive-prepare/tasks/main.yml
@@ -38,13 +38,6 @@
   args:
     chdir: '{{github_folder}}/jhipster.github.io/'
 
-- name: 'create Gemfile'
-  shell: |
-    echo "source 'https://rubygems.org'" > Gemfile
-    echo "gem 'github-pages'">>Gemfile
-  args:
-    chdir: '{{github_folder}}/jhipster.github.io/'
-
 - name: 'Jekyll bundle install'
   shell: docker exec -w /srv/jekyll -i release-jhipster.tech bundle install
 


### PR DESCRIPTION
Attempt to fix https://github.com/jhipster/jhipster-ansible/issues/9. 

The `Gemfile` already exists with the following content, so it doesn't seem like we should overwrite it.

```ruby
source 'https://rubygems.org'
gem 'github-pages'
gem 'jekyll-redirect-from'
gem 'jemoji'

gem "webrick", "~> 1.7"
```